### PR TITLE
chore(deps-dev): bump mocha and prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "bumpp": "^10.1.0",
         "conventional-changelog-cli": "^5.0.0",
         "microbundle": "^0.15.1",
-        "mocha": "^11.0.1",
-        "prettier": "^3.2.5"
+        "mocha": "^11.2.2",
+        "prettier": "^3.5.3"
     }
 }


### PR DESCRIPTION
```diff
diff --git a/package.json b/package.json
index fbb965b..1f85190 100644
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "bumpp": "^10.1.0",
         "conventional-changelog-cli": "^5.0.0",
         "microbundle": "^0.15.1",
-        "mocha": "^11.0.1",
-        "prettier": "^3.2.5"
+        "mocha": "^11.2.2",
+        "prettier": "^3.5.3"
     }
 }
```